### PR TITLE
remove redundant close tags

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -40,6 +40,3 @@
 <!-- Scripts -->
 <!--[if lte IE 8]><script src="{{ site.url }}{{ site.baseurl }}/assets/js/ie/respond.min.js"></script><![endif]-->
 <script src="{{ site.url }}{{ site.baseurl }}/assets/js/main.js"></script>
-
-</body>
-</html>


### PR DESCRIPTION
The layout file already contains a set of closing tags.

https://github.com/andrewbanchich/eventually-jekyll-theme/blob/2b9546187ca55f4d4bbcf84caf6faa8810cd7a89/_layouts/default.html#L21-L26